### PR TITLE
Install {cec2013} from Github

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,9 +18,11 @@ License: GPL (>= 3)
 URL: https://github.com/ewarchul/cecs
 Depends: R (>= 3.5.0)
 Imports: stringr (>= 1.4.0), cec2013 (>= 0.1.5)
+Remotes:  
+  ewarchul/cec2013
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Suggests: testthat (>= 3.0.0), purrr (>= 0.3.4)
 Config/testthat/edition: 3
 NeedsCompilation: yes


### PR DESCRIPTION
The package {cec2013} is no longer available on the CRAN repository and has to be installed from the github repository.